### PR TITLE
BUG: Actually use angles passed to forward and backward methods

### DIFF
--- a/src/python/torch_radon/radon.py
+++ b/src/python/torch_radon/radon.py
@@ -82,7 +82,7 @@ class BaseRadon:
 
         self.projection.cfg.n_angles = len(angles)
 
-        y = RadonForward.apply(x, self.angles, self.tex_cache, self.volume.to_cfg(), self.projection.cfg,
+        y = RadonForward.apply(x, angles, self.tex_cache, self.volume.to_cfg(), self.projection.cfg,
                                self.exec_cfg_generator, exec_cfg)
 
         return shape_normalizer.unnormalize(y)
@@ -109,7 +109,7 @@ class BaseRadon:
 
         self.projection.cfg.n_angles = len(angles)
 
-        y = RadonBackprojection.apply(sinogram, self.angles, self.tex_cache, volume.to_cfg(), self.projection.cfg,
+        y = RadonBackprojection.apply(sinogram, angles, self.tex_cache, volume.to_cfg(), self.projection.cfg,
                                       self.exec_cfg_generator, exec_cfg)
 
         return shape_normalizer.unnormalize(y)


### PR DESCRIPTION
The forward and backward methods of the BaseRadon class accept an `angles` parameter, but they don't actually use it!