### PR TITLE
BUG: Fix numpy assertion error.

### DIFF
--- a/src/python/torch_radon/filtering.py
+++ b/src/python/torch_radon/filtering.py
@@ -53,8 +53,8 @@ class FourierFilters:
         """
         filter_name = filter_name.lower()
 
-        n = np.concatenate((np.arange(1, size / 2 + 1, 2, dtype=np.int),
-                            np.arange(size / 2 - 1, 0, -2, dtype=np.int)))
+        n = np.concatenate((np.arange(1, size / 2 + 1, 2, dtype=int),
+                            np.arange(size / 2 - 1, 0, -2, dtype=int)))
         f = np.zeros(size)
         f[0] = 0.25
         f[1::2] = -1 / (np.pi * n) ** 2


### PR DESCRIPTION
This PR resolves `numpy` assertion error :
- Located at `src/python/torch_radon/filtering.py`.
- `np.int` in higher numpy version will cause `AttributeError: module 'numpy' has no attribute 'int'`. This was fixed by simply replacing `np.int` with `int`.